### PR TITLE
python3 is required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ There are instructions for installing in a 64-bit Debian based Linux environment
 
 The following packages will be required::
 
-    $ sudo apt-get install python-virtualenv python-pip python-dev git zlib1g:amd64 build-essential
+    $ sudo apt-get install python-virtualenv python3-pip python3-dev git zlib1g:amd64 build-essential
 
 Start by cloning the repository::
 
@@ -28,7 +28,7 @@ Create the symlink below, that is required by PIL for PNG support::
 
 Install python requirements::
 
-    $ pip install -r requirements.txt
+    $ pip3 install -r requirements.txt
 
 Download PhantomJS::
 

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,9 @@ The following packages will be required::
 
     $ sudo apt-get install python-virtualenv python3-pip python3-dev git zlib1g:amd64 build-essential
 
+You also need to install `python3-lilv` from KXStudio repositories. Please, follow
+the [KXStudio instructions](http://kxstudio.sourceforge.net/Repositories).
+
 Start by cloning the repository::
 
     $ git clone --recursive https://github.com/portalmod/mod-ui.git


### PR DESCRIPTION
I don't know if this pull is the best approach, but python3 is a dependency, right ? Also added the python3-lilv dependency instructions.